### PR TITLE
Add Gemfile, use redcarpet, fix *.html.md issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'jekyll', '3.0.1'
+gem 'redcarpet'
+gem 'rouge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,42 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    colorator (0.1)
+    ffi (1.9.10)
+    jekyll (3.0.1)
+      colorator (~> 0.1)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 3.0)
+      mercenary (~> 0.3.3)
+      rouge (~> 1.7)
+      safe_yaml (~> 1.0)
+    jekyll-sass-converter (1.3.0)
+      sass (~> 3.2)
+    jekyll-watch (1.3.0)
+      listen (~> 3.0)
+    kramdown (1.9.0)
+    liquid (3.0.6)
+    listen (3.0.5)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+    mercenary (0.3.5)
+    rb-fsevent (0.9.6)
+    rb-inotify (0.9.5)
+      ffi (>= 0.5.0)
+    redcarpet (3.3.3)
+    rouge (1.10.1)
+    safe_yaml (1.0.4)
+    sass (3.4.19)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll (= 3.0.1)
+  redcarpet
+  rouge
+
+BUNDLED WITH
+   1.10.6

--- a/_config.yml
+++ b/_config.yml
@@ -6,13 +6,12 @@ description: > # this means to ignore newlines until "baseurl:"
   Slide decks for 18F [Consulting]!
 
 baseurl: "/slides"
-url: "https://18f.github.io"
+url: "https://pages.18f.gov/slides/"
 
 # Build settings
-markdown: kramdown
-markdown_ext: ignoreme
+markdown: redcarpet
 
 collections:
-    slides:
-        output: true
-        permalink: "/:path/"
+  slides:
+    output: true
+    permalink: "/:path/"


### PR DESCRIPTION
@vzvenyach reported that https://pages.18f.gov/slides/google-apps/ wasn't working as expected. It turns out that the `markdown_ext: ignoreme` setting in `_config.yml` was causing the rendered `_slides` pages to show up with the extension `.html.md`.

Removed this configuration item, switched the Markdown rendering engine fromkramdown to redcarpet, and added a Gemfile for good measure. Confirmed locally that this resolves the issue at http://localhost:4000/slides/google-apps/#/.

Ready for you to merge, @vzvenyach.
